### PR TITLE
Resolve Issue: Unable to Use WPUM Blocks in WP Editor

### DIFF
--- a/blocks-loader.php
+++ b/blocks-loader.php
@@ -70,6 +70,7 @@ class WPUM_Blocks {
 			'wp-element',
 			'wp-components',
 			'wp-editor',
+			'lodash',
 		], WPUM_VERSION );
 
 		wp_enqueue_style( 'wpum-blocks-admin', WPUM_PLUGIN_URL . 'vendor/wp-user-manager/wpum-blocks/build/style.css', [], WPUM_VERSION );


### PR DESCRIPTION
Resolves https://github.com/WPUserManager/wp-user-manager/issues/390

## Description
Lodash has been included as a script dependency for the wpum-block script to resolve the issue of WPUM blocks being unusable in the WordPress block editor.

## Testing Instructions

1.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
